### PR TITLE
moving -> around

### DIFF
--- a/quickstart.malloynb
+++ b/quickstart.malloynb
@@ -310,18 +310,16 @@ Literals of type `date` and `timestamp` are notated with an `@`, e.g. `@2003-03-
 Time literals can be used as values, but are more often useful in filters. For example, the following query
 shows the number of flights in 2003.
 >>>malloy
-run: duckdb.table('data/flights.parquet') {
+run: duckdb.table('data/flights.parquet') -> {
   where: dep_time ? @2003
-} -> {
   aggregate: flight_count is count()
 }
 >>>markdown
 
 There is a special time literal `now`, referring to the current timestamp, which allows for relative time filters.
 >>>malloy
-run: duckdb.table('data/flights.parquet') {
+run: duckdb.table('data/flights.parquet') -> {
   where: dep_time > now - 6 hours
-} -> {
   aggregate: flights_last_6_hours is count()
 }
 >>>markdown
@@ -359,7 +357,8 @@ And likewise for any other data type that has interesting output metadata. -->
 
 Two kinds of time ranges are given special syntax: the range between two times and the range starting at some time for some duration. These are represented like `@2003 to @2005` and `@2004-Q1 for 6 quarters` respectively. These ranges can be used in filters just like time literals.
 >>>malloy
-run: duckdb.table('data/flights.parquet') { where: dep_time ? @2003 to @2005 } -> {
+run: duckdb.table('data/flights.parquet') -> {
+  where: dep_time ? @2003 to @2005
   aggregate: flight_count is count()
 }
 >>>markdown
@@ -369,7 +368,8 @@ timeframe from the truncation, e.g. `now.month` means the entirety of the curren
 
 When a time range is used in a comparison, `=` checks for "is in the range", `>` "is after", and `<` "is before." So `some_time > @2003` filters dates starting on January 1, 2004, while `some_time = @2003` filters to dates in the year 2003.
 >>>malloy
-run: duckdb.table('data/flights.parquet') { where: dep_time > @2003 } -> {
+run: duckdb.table('data/flights.parquet') -> {
+  where: dep_time > @2003
   top: 3; order_by: departure_date asc
   group_by: departure_date is dep_time.day
   aggregate: flight_count is count()


### PR DESCRIPTION
The master branch was giving errors in several malloynb cells, this was due to old fashioned filtering methods, and use of -> stages. I moved these around, and now they work well. I confirmed the problem in wasm and desktop vscode. 